### PR TITLE
fix component.md

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -3141,7 +3141,7 @@ export default defineComponent({
 
 ```vue
 <template>
-  <div v-foo="foo"></div>
+  <div v-foo="foo">{{ foo.bar.baz }}</div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
The hook function will only be executed when the element bound to the directive is updated, but in the current example, the element is not using foo, causing the hook function to not be executed when debugging.