### PR TITLE
fix:  typescript.md

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -60,7 +60,7 @@ TypeScript 语言对应的文件扩展名是 `.ts` 。
 2. [ts-node](https://www.npmjs.com/package/ts-node) 是让 Node 可以运行 TypeScript 的执行环境
 
 ```bash
-npm install -D typescript ts-node
+npm install -D typescript ts-node @types/node
 ```
 
 这次添加了一个 `-D` 参数，因为 TypeScript 和 TS-Node 是开发过程中使用的依赖，所以将其添加到 package.json 的 `devDependencies` 字段里。


### PR DESCRIPTION
Add @types/node dependency to resolve error: 
``` 
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
src/ts/index.ts:3:3 - error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.

3   console.log(msg.split(' ')[0])
    ~~~~~~~
```